### PR TITLE
corex.js: Date Timezone Bug

### DIFF
--- a/CorexJs/js/corex.js
+++ b/CorexJs/js/corex.js
@@ -1195,7 +1195,7 @@
             return new Date(y, m - 1);
         if (y != null)
             return new Date(y);
-        var x = new Date(0);
+        var x = new Date(1970, 0, 1);
         x.setHours(0, 0, 0, 0);
         return x;
     }


### PR DESCRIPTION
Problem:
- Your timezone is GMT -x as many parts of the US are, say GMT-5
- It happens to be the 25th of June, and you want today's epoch

What happens:
- You get back an epoch of the 25th of July

Why:
- A date gets instantiated with date = new Date(0);
- When it was Jan. 1st 1970 00:00:00 at Greenwich, it was Dec. 31st 1969
  19:00:00 at GMT-5.
- Because the "date" field is now 31st, and not all months have the 31st day,
  if you set the "month" field to June, it doesn't know what to do. Well,
  ostensibly, it doesn't, what it does is it goes to the 'conceptual' June 31st,
  which is actually July the 1st.
  
  Now you're in the completely wrong month, without having asked for it.

Solution:
- Instantiate it to Jan 1st. 1970, whatever timezone you are in. This should be
  a sufficiently blank slate to create any day of the year from.

Patch initially authored by Ifty Haque https://github.com/iftekhar25/
Patch revised by Dan-el Khen https://github.com/danelkhen/
